### PR TITLE
Add Matchers for Chefspec

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,51 +1,19 @@
 if defined?(ChefSpec)
 
-  def create_deploy_key_bitbucket(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_bitbucket, :create, resource_name)
+  def create_deploy_key(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key, :create, resource_name)
   end
   
-  def delete_deploy_key_bitbucket(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_bitbucket, :delete, resource_name)
+  def delete_deploy_key(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key, :delete, resource_name)
   end
 
-  def add_deploy_key_bitbucket(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_bitbucket, :add, resource_name)
+  def add_deploy_key(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key, :add, resource_name)
   end
 
-  def remove_deploy_key_bitbucket(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_bitbucket, :remove, resource_name)
-  end
-
-  def create_deploy_key_github(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_github, :create, resource_name)
-  end
-  
-  def delete_deploy_key_github(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_github, :delete, resource_name)
-  end
-
-  def add_deploy_key_github(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_github, :add, resource_name)
-  end
-
-  def remove_deploy_key_github(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_github, :remove, resource_name)
-  end
-
-  def create_deploy_key_gitlab(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_gitlab, :create, resource_name)
-  end
-  
-  def delete_deploy_key_gitlab(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_gitlab, :delete, resource_name)
-  end
-
-  def add_deploy_key_gitlab(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_gitlab, :add, resource_name)
-  end
-
-  def remove_deploy_key_gitlab(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key_gitlab, :remove, resource_name)
+  def remove_deploy_key(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:deploy_key, :remove, resource_name)
   end
 
 end


### PR DESCRIPTION
- Add methods:
  - create_deploy_key
  - delete_deploy_key
  - add_deploy_key
  - remove_deploy_key
- Example:

```
require 'chefspec'

describe 'example::default' do
  let(:chef_run) { ChefSpec::SoloRunner.converge(described_recipe) }

  it 'deploy key foo' do
    expect(chef_run).to create_deploy_key('foo')
  end
end
```
