### PR TITLE
Client certificate support

### DIFF
--- a/libraries/deploy_key.rb
+++ b/libraries/deploy_key.rb
@@ -58,6 +58,8 @@ module DeployKey
     if url.instance_of?  URI::HTTPS
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.cert = OpenSSL::X509::Certificate.new(new_resource.client_cert) unless new_resource.client_cert.nil?
+      http.key = OpenSSL::PKey::RSA.new(new_resource.client_key) unless new_resource.client_key.nil?
     end
     http.request(req)
   end

--- a/providers/gitlab.rb
+++ b/providers/gitlab.rb
@@ -64,7 +64,9 @@ action :add do
     Chef::Log.info("Deploy key #{new_resource.label} already added - nothing to do.")
   else
     converge_by("Register #{new_resource}") do
-      add_key(new_resource.label, pubkey)
+      label = new_resource.deploy_key_label.nil? ? new_resource.label : new_resource.deploy_key_label
+
+      add_key(label, pubkey)
     end
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -34,3 +34,7 @@ attribute :group, :kind_of => String, :default => "root"
 attribute :mode, :default => 00600
 
 attribute :api_url, :kind_of => String, :default => nil
+
+# Client certificate support
+attribute :client_cert, :kind_of => String, :default => nil
+attribute :client_key, :kind_of => String, :default => nil

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -17,6 +17,8 @@ default_action :add
 
 attribute :label, :kind_of => String, :name_attribute => true
 attribute :path, :kind_of => String, :required => true
+attribute :deploy_key_label, :kind_of => String, :default => nil
+
 
 # For OAuth: { :token => token }
 # For user/pass: { :user => user, :password => password }


### PR DESCRIPTION
This will allow the deploy key resource to be able to connect to an API url that requires client certificates.
